### PR TITLE
fix: 修复配置丢失问题并添加重置配置功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-bookmark",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A bookmark manager for Chrome.",
   "author": "ETY001 <work@akawa.ink>",
   "license": "MIT",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -142,5 +142,17 @@
   },
   "privacy_policy": {
     "message": "Review Bookmarks will collect anonymously how freqency to display/block/manage bookmarks, if you have agreed. These data will help author to improve the extension's experience."
+  },
+  "reset_config": {
+    "message": "Reset Config"
+  },
+  "reset_config_title": {
+    "message": "Reset Configuration"
+  },
+  "reset_config_description": {
+    "message": "Are you sure you want to reset all configurations to default values? This will restore all settings to their initial state, but will not delete bookmark data."
+  },
+  "reset_success": {
+    "message": "Reset success"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -142,5 +142,17 @@
   },
   "privacy_policy": {
     "message": "如果同意，温故知新将会匿名地收集用户的展示/屏蔽/整理书签的频率，这将帮助作者提升扩展的使用体验。"
+  },
+  "reset_config": {
+    "message": "重置配置"
+  },
+  "reset_config_title": {
+    "message": "重置配置"
+  },
+  "reset_config_description": {
+    "message": "确定要重置所有配置为默认值吗？此操作将恢复所有设置到初始状态，但不会删除书签数据。"
+  },
+  "reset_success": {
+    "message": "重置成功"
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     name: '__MSG_appname__',
     description: '__MSG_appdesc__',
     default_locale: 'en',
-    version: '4.0.0',
+    version: '4.0.1',
     // 修改：author 改为字符串格式（Firefox 要求）
     // 使用类型断言绕过 WXT 的类型检查，因为 Firefox 需要字符串格式
     author: 'work@akawa.ink' as any,


### PR DESCRIPTION
- 删除自动清空配置的逻辑（curt_index 检查），修复配置丢失bug
- 在 popup 页面添加重置配置按钮和确认对话框
- 添加 reset_config 消息处理，支持重置配置为默认值
- 添加重置配置相关的国际化文本（中英文）
- 更新版本号至 4.0.1