### PR TITLE
feat: 添加迷你模式自动关闭弹层功能

### DIFF
--- a/components/ContentNotification.tsx
+++ b/components/ContentNotification.tsx
@@ -119,9 +119,11 @@ export function ContentNotification({
           </svg>
         </button>
       </div>
-      <div className="rb-notification-countdown">
-        {countdown}秒后关闭
-      </div>
+      {countdown > 0 && (
+        <div className="rb-notification-countdown">
+          {countdown}秒后关闭
+        </div>
+      )}
     </div>
   );
 }

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -77,7 +77,7 @@ async function getUid(): Promise<string> {
 }
 
 // Google Analytics 4
-let currentVersion = '4_0_1';
+let currentVersion = '4_0_2';
 if (isChrome()) {
   currentVersion = `chrome_${currentVersion}`;
 } else if (isFirefox()) {
@@ -336,6 +336,8 @@ if (typeof chrome !== 'undefined' && chrome.runtime) {
           frequency: cdata.frequency,
           currentNotifyLocation: cdata.currentNotifyLocation,
           ga: cdata.ga,
+          autoClose: cdata.autoClose,
+          autoCloseDelay: cdata.autoCloseDelay,
         });
         sendResponse({ ctype, cdata: true });
         return false;
@@ -353,6 +355,8 @@ if (typeof chrome !== 'undefined' && chrome.runtime) {
           frequency: 5,
           currentNotifyLocation: 'top-right',
           ga: false,
+          autoClose: false,
+          autoCloseDelay: 30,
         });
         // 重置频度计数器
         useStore.setState({ frequencyCounter: 0 });

--- a/entrypoints/content-script.tsx
+++ b/entrypoints/content-script.tsx
@@ -62,7 +62,9 @@ function App() {
   const [position, setPosition] = useState<'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'>('top-right');
   const [blockDialogOpen, setBlockDialogOpen] = useState(false);
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
-  const [countdown, setCountdown] = useState<number>(15);
+  const [countdown, setCountdown] = useState<number>(0);
+  const [autoClose, setAutoClose] = useState<boolean>(false);
+  const [autoCloseDelay, setAutoCloseDelay] = useState<number>(30);
 
   const handleClose = useCallback(() => {
     if (notificationContainer) {
@@ -106,6 +108,8 @@ function App() {
           if (response.cdata.bookmark) {
             setBookmark(response.cdata.bookmark);
             setPosition(response.cdata.config?.currentNotifyLocation || 'top-right');
+            setAutoClose(response.cdata.config?.autoClose ?? false);
+            setAutoCloseDelay(response.cdata.config?.autoCloseDelay ?? 30);
           }
         }
       }
@@ -146,13 +150,13 @@ function App() {
 
   // 倒计时和自动关闭
   useEffect(() => {
-    if (!bookmark) {
-      setCountdown(15);
+    if (!bookmark || !autoClose) {
+      setCountdown(0);
       return;
     }
 
     // 重置倒计时
-    setCountdown(15);
+    setCountdown(autoCloseDelay);
 
     // 倒计时定时器
     const timer = setInterval(() => {
@@ -169,7 +173,7 @@ function App() {
     return () => {
       clearInterval(timer);
     };
-  }, [bookmark, handleClose]);
+  }, [bookmark, autoClose, autoCloseDelay, handleClose]);
 
   // 渲染通知
   useEffect(() => {

--- a/entrypoints/popup/App.tsx
+++ b/entrypoints/popup/App.tsx
@@ -24,6 +24,8 @@ interface FormData {
   frequency: number;
   currentNotifyLocation: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
   ga: boolean;
+  autoClose: boolean;
+  autoCloseDelay: number;
 }
 
 const notifyLocations = [
@@ -59,6 +61,8 @@ export default function App() {
             frequency: 5,
             currentNotifyLocation: 'top-right',
             ga: false,
+            autoClose: false,
+            autoCloseDelay: 30,
           });
           return;
         }
@@ -71,6 +75,8 @@ export default function App() {
             frequency: config.frequency ?? 5,
             currentNotifyLocation: config.currentNotifyLocation ?? 'top-right',
             ga: config.ga ?? false,
+            autoClose: config.autoClose ?? false,
+            autoCloseDelay: config.autoCloseDelay ?? 30,
           });
           setDisplayGaReminder(config.ga === true ? 'hidden' : 'display');
         } else {
@@ -82,6 +88,8 @@ export default function App() {
             frequency: 5,
             currentNotifyLocation: 'top-right',
             ga: false,
+            autoClose: false,
+            autoCloseDelay: 30,
           });
         }
       }
@@ -93,6 +101,16 @@ export default function App() {
 
     // 验证
     if (formData.frequency && (!Number.isInteger(formData.frequency) || formData.frequency < 1)) {
+      toast({
+        variant: 'warning',
+        title: getMessage('save_failed'),
+        description: getMessage('need_integer'),
+      });
+      return;
+    }
+
+    // 验证自动关闭延迟
+    if (formData.autoClose && (!Number.isInteger(formData.autoCloseDelay) || formData.autoCloseDelay < 1)) {
       toast({
         variant: 'warning',
         title: getMessage('save_failed'),
@@ -160,6 +178,8 @@ export default function App() {
                   frequency: config.frequency ?? 5,
                   currentNotifyLocation: config.currentNotifyLocation ?? 'top-right',
                   ga: config.ga ?? false,
+                  autoClose: config.autoClose ?? false,
+                  autoCloseDelay: config.autoCloseDelay ?? 30,
                 });
                 setDisplayGaReminder(config.ga === true ? 'hidden' : 'display');
               }
@@ -284,6 +304,38 @@ export default function App() {
                       </SelectContent>
                     </Select>
                   </div>
+
+                  <div className="flex items-center justify-between">
+                    <label className="text-sm font-medium w-[140px] text-left">
+                      {getMessage('auto_close')}
+                    </label>
+                    <Switch
+                      checked={formData.autoClose}
+                      onCheckedChange={(checked) =>
+                        setFormData({ ...formData, autoClose: checked })
+                      }
+                    />
+                  </div>
+
+                  {formData.autoClose && (
+                    <div className="flex items-center justify-between">
+                      <label className="text-sm font-medium w-[140px] text-left">
+                        {getMessage('auto_close_delay')}
+                      </label>
+                      <Input
+                        type="number"
+                        value={formData.autoCloseDelay}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            autoCloseDelay: parseInt(e.target.value) || 30,
+                          })
+                        }
+                        className="w-[200px]"
+                        min="1"
+                      />
+                    </div>
+                  )}
                 </>
               )}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-bookmark",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A bookmark manager for Chrome.",
   "author": "ETY001 <work@akawa.ink>",
   "license": "MIT",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -154,5 +154,11 @@
   },
   "reset_success": {
     "message": "Reset success"
+  },
+  "auto_close": {
+    "message": "Auto Close"
+  },
+  "auto_close_delay": {
+    "message": "Auto Close Delay (seconds)"
   }
 }

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -154,5 +154,11 @@
   },
   "reset_success": {
     "message": "重置成功"
+  },
+  "auto_close": {
+    "message": "自动关闭"
+  },
+  "auto_close_delay": {
+    "message": "自动关闭延迟（秒）"
   }
 }

--- a/store/index.ts
+++ b/store/index.ts
@@ -11,6 +11,8 @@ export interface Config {
   frequency: number; // mini 模式展示频度
   currentNotifyLocation: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'; // 当前 Mini 提醒框位置
   ga: boolean; // Google Analytics Status
+  autoClose: boolean; // 是否自动关闭弹层
+  autoCloseDelay: number; // 自动关闭延迟秒数
 }
 
 /**
@@ -57,6 +59,8 @@ const defaultConfig: Config = {
   frequency: 5,
   currentNotifyLocation: 'top-right',
   ga: false,
+  autoClose: false,
+  autoCloseDelay: 30,
 };
 
 /**

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     name: '__MSG_appname__',
     description: '__MSG_appdesc__',
     default_locale: 'en',
-    version: '4.0.1',
+    version: '4.0.2',
     // 修改：author 改为字符串格式（Firefox 要求）
     // 使用类型断言绕过 WXT 的类型检查，因为 Firefox 需要字符串格式
     author: 'work@akawa.ink' as any,


### PR DESCRIPTION
- 在配置中添加 autoClose 和 autoCloseDelay 字段
- 在 popup 页面添加自动关闭开关和延迟时间配置项
- 修改 content-script，根据配置实现自动关闭逻辑
- 仅在启用自动关闭时显示倒计时
- 更新 background 中的配置保存和重置逻辑
- 添加自动关闭相关的国际化文本（中英文）
- 更新版本号至 4.0.2